### PR TITLE
Simplify usage for external libs

### DIFF
--- a/utkdecode-bnb.c
+++ b/utkdecode-bnb.c
@@ -87,12 +87,17 @@ static void pt_read_header(PTContext *pt)
     write_u32(pt->outfp, pt->num_samples*2);
 }
 
+static size_t pt_read_callback(void *dest, int size, void *arg) {
+    return fread(dest, 1, size, arg);
+}
+
 static void pt_decode(PTContext *pt)
 {
     UTKContext *utk = &pt->utk;
+    uint8_t buffer[0x1000];
     uint32_t num_samples = pt->num_samples;
 
-    utk_set_fp(utk, pt->infp);
+    utk_set_callback(utk, buffer,0x1000, pt->infp, &pt_read_callback);
 
     while (num_samples > 0) {
         int count = MIN(num_samples, 432);

--- a/utkdecode-fifa.c
+++ b/utkdecode-fifa.c
@@ -137,12 +137,16 @@ static void ea_read_scdl(EAContext *ea)
 
     while (num_samples > 0) {
         int count = MIN(num_samples, 432);
-        int i;
+        int i, res;
 
         if (ea->codec_revision >= 3)
-            utk_rev3_decode_frame(utk);
+            res = utk_rev3_decode_frame(utk);
         else
-            utk_decode_frame(utk);
+            res = utk_decode_frame(utk);
+        if (res != 0) {
+            fprintf(stderr, "error: decode fail %i\n", res);
+            exit(EXIT_FAILURE);
+        }
 
         for (i = 0; i < count; i++) {
             int x = ROUND(ea->utk.decompressed_frame[i]);

--- a/utkdecode.c
+++ b/utkdecode.c
@@ -20,6 +20,10 @@
 #define MAX(x,y) ((x)>(y)?(x):(y))
 #define CLAMP(x,min,max) MIN(MAX(x,min),max)
 
+static size_t read_callback(void *dest, int size, void *arg) {
+    return fread(dest, 1, size, arg);
+}
+
 int main(int argc, char *argv[])
 {
     const char *infile, *outfile;
@@ -36,6 +40,7 @@ int main(int argc, char *argv[])
     uint16_t cbSize;
     uint32_t num_samples;
     FILE *infp, *outfp;
+    uint8_t buffer[0x1000];
     int force = 0;
     int error = 0;
     int i;
@@ -146,7 +151,7 @@ int main(int argc, char *argv[])
 
     /* Decode. */
     utk_init(&ctx);
-    utk_set_fp(&ctx, infp);
+    utk_set_callback(&ctx, buffer,0x1000, infp, &read_callback);
 
     while (num_samples > 0) {
         int count = MIN(num_samples, 432);


### PR DESCRIPTION
- return frame error instead of global exit on failure
- add read callback and buffers for non-FILE streams and multithreading access
- add reset function for loops
- add include .h guard

I tweaked the API a bit so it's easier to use as a multithread lib (for vgmstream, mainly).
Could be improved I guess, but I didn't want to deviate from the original too much.